### PR TITLE
Update and pin torch and torchvision versions in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ jupyter
 matplotlib
 pandas
 medmnist
-torch==1.13.1
-torchvision
+torch==2.3.1
+torchvision==0.18.1


### PR DESCRIPTION
Pinning `torch` and `torchvision`, to account for CVE-2024-31583 and CVE-2024-31580. In addition, the proposed versions have been tested for compatibility with OpenFL's latest v1.6 release.